### PR TITLE
Playwright MCP の Chrome から Chromium への変更

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -15,7 +15,7 @@ services:
     healthcheck:
       test: ["CMD", "curl", "http://localhost:8000/health" ]
       interval: 1s
-      retries: 10
+      retries: 30
   client:
     depends_on:
       playwright-mcp:

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -14,4 +14,4 @@ RUN apt-get update && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-RUN corepack enable pnpm && pnpm dlx playwright install --with-deps chrome
+RUN corepack enable pnpm && pnpm dlx playwright install --with-deps chromium

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -14,4 +14,4 @@ RUN apt-get update && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-RUN corepack enable pnpm && pnpm dlx playwright install --with-deps chromium
+RUN corepack enable pnpm && pnpm dlx playwright@1.56.1 install --with-deps chromium

--- a/containers/scripts/playwright.config.json
+++ b/containers/scripts/playwright.config.json
@@ -4,10 +4,12 @@
 		"port": 8000
 	},
 	"browser": {
+		"browserName": "chromium",
 		"isolated": true,
 		"launchOptions": {
 			"headless": false,
-			"args": ["--no-sandbox", "--disable-dev-shm-usage", "--no-zygote"]
+			"args": ["--no-sandbox", "--disable-dev-shm-usage", "--no-zygote"],
+			"executablePath": "/root/.cache/ms-playwright/chromium-1194/chrome-linux/chrome"
 		},
 		"contextOptions": {
 			"viewport": {


### PR DESCRIPTION
close #1 

## 変更内容

- **Dockerfile 更新**: `playwright install --with-deps chrome` を `chromium` に変更
- **Playwright 設定追加**: 
  - `browserName: "chromium"` を明示的に指定
  - `executablePath` で Chromium バイナリのパスを指定
