### PR TITLE
Docker ベースイメージのバージョン固定

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-slim
+FROM node:24-slim@sha256:76d0ed0ed93bed4f4376211e9d8fddac4d8b3fbdb54cc45955696001a3c91152
 WORKDIR /app
 
 RUN apt-get update && \

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine
+FROM node:24-alpine@sha256:f36fed0b2129a8492535e2853c64fbdbd2d29dc1219ee3217023ca48aebd3787
 
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate


### PR DESCRIPTION
## 概要

ベースイメージをSHA256ダイジェストで固定

## 変更内容

- **containers/Dockerfile**: `node:24-slim` を SHA256 ダイジェスト付きで固定
- **packages/client/Dockerfile**: `node:24-alpine` を SHA256 ダイジェスト付きで固定
